### PR TITLE
Add the local_xmlsync plugin + core hooks

### DIFF
--- a/enrol/database/lib.php
+++ b/enrol/database/lib.php
@@ -709,8 +709,10 @@ class enrol_database_plugin extends enrol_plugin {
                         $trace->output('error: invalid external course record, shortname and fullname are mandatory: ' . json_encode($fields), 1); // Hopefully every geek can read JS, right?
                         continue;
                     }
-                    if ($DB->record_exists('course', array('shortname'=>$fields[$shortname_l]))) {
+                    if ($record = $DB->record_exists('course', array('shortname'=>$fields[$shortname_l]))) {
                         // Already exists, skip.
+                        // WR#371794: Add hiding/unhiding of existing courses
+                        \local_xmlsync\util::enrol_database_course_update_hook($record);
                         continue;
                     }
                     // Allow empty idnumber but not duplicates.
@@ -738,6 +740,8 @@ class enrol_database_plugin extends enrol_plugin {
                     } else {
                         $course->category = $defaultcategory;
                     }
+                    // WR#371794: Add hiding/unhiding.
+                    \local_xmlsync\util::enrol_database_course_hook($course);
                     $createcourses[] = $course;
                 }
             }
@@ -805,6 +809,12 @@ class enrol_database_plugin extends enrol_plugin {
                     continue;
                 } else if (!empty($newcourse->idnumber) and $DB->record_exists('course', array('idnumber' => $newcourse->idnumber))) {
                     $trace->output("can not insert new course, duplicate idnumber detected: ".$newcourse->idnumber, 1);
+                    continue;
+                }
+                // WR#371793: Clone content from template course, if there is an individual template.
+                if (\local_xmlsync\util::enrol_database_template_check($newcourse->idnumber)) {
+                    \local_xmlsync\util::enrol_database_template_hook($newcourse);
+                    $trace->output("creating new course, cloning from template: $c->fullname, $c->shortname, $c->idnumber, $c->category", 1);
                     continue;
                 }
                 $c = create_course($newcourse);

--- a/local/xmlsync/classes/import/base_importer.php
+++ b/local/xmlsync/classes/import/base_importer.php
@@ -1,0 +1,491 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Base XML importer
+ *
+ * @package    local_xmlsync
+ * @author     David Thompson <david.thompson@catalyst.net.nz>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_xmlsync\import;
+
+use dml_exception;
+use coding_exception;
+use Exception;
+use moodle_exception;
+use stdClass;
+
+defined('MOODLE_INTERNAL') || die();
+
+abstract class base_importer {
+    // Constants common to all importers / XML formats.
+    const XMLROWSET = "ROWSET";
+    const XMLROW = "ROW";
+    const XMLROWCOUNT = "ROWCOUNT";
+    const XMLACTION = "ACTION";
+
+    const ACTION_UPDATE = "U"; // Includes inserts.
+    const ACTION_DELETE = "D";
+
+    const ROW_INSERT = 1;
+    const ROW_UPDATE = 2;
+    const ROW_DELETE = 3;
+    const ROW_NOTEXIST = 4;
+
+    //Default amount of records to read from the XML file before inserting into the db via insert_records
+    const BATCH_COUNT = 1000;
+
+    /**
+     * The filename of the source file for this importer
+     * @var string|null
+     */
+    public $filename = null;
+
+    /**
+     * The table the xml document is imported to
+     * @var string|null
+     */
+    public $import_temp_tablename = null;
+    /**
+     * The table that contains the result of all
+     * delta files that are applied
+     * @var string|null
+     */
+    public $import_main_tablename = null;
+
+    /**
+     * Import count from last import, if any.
+     * Set during task initialisation.
+     * @var int|null
+     */
+    public $lastimportcount = null;
+
+    /**
+     * Source timestamp from last import, if any.
+     * Set during task initialisation.
+     * @var int|null
+     */
+    public $lastsourcetimestamp = null;
+
+    /**
+     * Mapping from incoming XML field names to database column names.
+     *
+     * Override this in subclasses.
+     * @var int[]|null
+     */
+    public $rowmapping = null;
+
+    /**
+     * Constructor.
+     */
+    public function __construct() {
+        $this->filepath = $this->get_filepath(get_config('local_xmlsync', 'syncpath'), $this->filename);
+        $this->reader = new \XMLReader();
+        if (!$this->reader->open($this->filepath)) {
+            throw new \Exception(get_string('error:noopen', 'local_xmlsync', $this->filepath));
+        }
+    }
+
+    /**
+     * Helper: join up filepaths.
+     *
+     * @param string $basepath
+     * @param string $filename
+     * @throws \Exception when syncpath is empty.
+     * @return string
+     */
+    protected function get_filepath($basepath, $filename) : string {
+        $parts = array($basepath, $filename);
+
+        if (empty($basepath)) {
+            throw new \Exception(get_string('error:nosyncpath', 'local_xmlsync'));
+        }
+
+        // Deal with doubled slashes.
+        return preg_replace('#/+#', '/', join('/', $parts));
+    }
+
+    /**
+     * After we have completed the import of the XML delta file into
+     * a table, we can now compare it against the master table
+     * and do any necessary delete or updates in bulk
+     * @return bool true if any changes were made, otherwise false
+     */
+    public function sync() {
+        global $DB;
+
+
+
+        $transaction = $DB->start_delegated_transaction();
+        try {
+            $importtable = $this->import_temp_tablename;
+            $maintable = $this->import_main_tablename;
+            $metadata = new stdClass();
+            $metadata->importtable = $importtable;
+            $metadata->maintable = $maintable;
+            $metadata->pre_sync_total = $DB->count_records($maintable);
+            mtrace(get_string('sync:start', 'local_xmlsync', $metadata));
+
+            $creates = $this->get_records_to_create($importtable, $maintable);
+            $metadata->insertcount = $this->insert_records($maintable, $creates);
+
+            $updates = $this->get_records_to_update($importtable, $maintable);
+            $metadata->updatecount = $this->update_records($maintable, $updates);
+
+            $deletes = $this->get_records_to_delete($importtable, $maintable);
+            $metadata->deletecount = $this->delete_records($maintable, $deletes);
+
+            $metadata->post_sync_total = $DB->count_records($maintable);
+
+            //The previous total minus deleted + any inserted does not equal the post sync total, something is wrong!
+            if( ( ( $metadata->pre_sync_total - $metadata->deletecount ) + $metadata->insertcount ) != $metadata->post_sync_total ) {
+                throw new moodle_exception(get_string('sync:countinvalid', 'local_xmlsync', $metadata));
+            }
+
+            $delta = abs($metadata->pre_sync_total - $metadata->post_sync_total);
+            $metadata->delta = $delta;
+
+            $maxdelta = get_config('local_xmlsync', 'import_count_threshold');
+            $metadata->maxdelta = $maxdelta;
+            if ($maxdelta && $maxdelta > 0 && $maxdelta < $delta) {
+                //There is too much change in the table for our tastes, lets fail out instead
+                throw new moodle_exception(get_string('error:importcountoverthreshold', 'local_xmlsync', $metadata));
+            }
+        }
+        catch (Exception $e) {
+            //If anything goes wrong we throw away the attempted update to the main table, then rethrow the
+            //exception for task handling to deal with.
+            $transaction->rollback($e);
+            throw $e;
+        }
+        mtrace(get_string('sync:complete', 'local_xmlsync', $metadata));
+        //We're now happy that the sync completed in a clean manner and commit the change to be visible
+        $transaction->allow_commit();
+
+    }
+
+    protected function sanity_check_import_table($importtable) {
+        //Child classes can implement custom sanity checks here and create warnings
+        return;
+    }
+
+    /**
+     * Given two tables, return an array of records that need to be created
+     * they should be in the form the main table expects
+     * @param mixed $importtable 
+     * @param mixed $maintable 
+     * @return stdClass[] Array of records to create, should be in the form the maintable variable expects
+     */
+    abstract function get_records_to_create($importtable, $maintable);
+
+
+    /**
+     * Given two tables, return an array of records that need to be updated in place
+     * they should be in the form the main table expects
+     * @param mixed $importtable 
+     * @param mixed $maintable 
+     * @return stdClass[] Array of records to update, should be in the form the maintable variable expects, and have the id record of the maintable item to update
+     */
+    abstract function get_records_to_update($importtable, $maintable);
+
+    /**
+     * Given two tables, return an array of records that need to be deleted from the main table
+     * at the very least the record must have an id field corresponding to the main table record to delete
+     * @param mixed $importtable 
+     * @param mixed $maintable 
+     * @return stdClass[] Array of records to update, **must** have the id record of the maintable item to remove
+     */
+    abstract function get_records_to_delete($importtable, $maintable);
+
+    /**
+     * Given an import temporary table and a main table, this will calculate
+     * A select sql fragment that selects every column from the temp table that
+     * is present in the maintable (except the id).
+     * 
+     * A where sql fragment that checks if any column in the maintable does not matches
+     * every column in the import table (except the id column)
+     * 
+     * Together these can be used as part of individual import classes update records
+     * check to get only the minimal record needing changes
+     * @param mixed $importtable 
+     * @param mixed $maintable 
+     * @return string[] array($selectsql, $wheresql) fragments
+     * @throws coding_exception 
+     */
+    protected function get_update_sql_helpers($importtable, $maintable) {
+        global $DB;
+        $select = [];
+        $where = [];
+        $columns = $DB->get_columns($maintable);
+        foreach($columns as $column) {
+            if($column->name == 'id') {
+                continue;
+            }
+            
+            //Account for mariadb/mysql not being case sensitive matching by default
+            $sql = $DB->sql_equal('import.'.$column->name, 'main.'.$column->name, true, true, true);
+            $select[] ='import.'.$column->name;
+            $where[] = $sql;
+        }
+        $selectsql = implode(',', $select);
+        $wheresql = implode(' OR ', $where);
+        return array($selectsql, $wheresql);
+    }
+
+    /**
+     * Get the list of ID's to delete and then delete them with a
+     * delete records set call
+     * @param mixed $table 
+     * @param mixed $records 
+     * @return int 
+     * @throws coding_exception 
+     */
+    protected function delete_records($table, $records) {
+        global $DB;
+        $deleteids = array();
+        //Get a list of ID's to remove
+        foreach($records as $record) {
+            if(!isset($record->id) || $record->id == 0) {
+                //Something is very wrong, only a developer can fix this
+                throw new coding_exception("We were fed a record to delete that did not contain a valid id field" + print_r($record, true));
+            }
+            $deleteids[] = $record->id;
+        }
+        //If there are any, we do the work
+        if(count($deleteids) > 0) {
+            list($lsql, $params) = $DB->get_in_or_equal($deleteids);
+            $sql = 'id '.$lsql;
+            $DB->delete_records_select($table, $sql, $params);
+            return count($deleteids);//total deleted;
+        }
+        //Nothing to do
+        return 0;
+    }
+
+    /**
+     * Here, we just update records one by one
+     * @param mixed $table 
+     * @param mixed $records 
+     * @return int 
+     */
+    protected function update_records($table, $records) {
+        global $DB;
+        foreach($records as $record) {
+            $DB->update_record($table, $record);
+        }
+        return count($records);
+    }
+
+    protected function insert_records($table, $records) {
+        global $DB;
+        $DB->insert_records($table, $records);
+        return count($records);
+    }
+    /**
+     * We have an XML document, now we import it straight into
+     * the temporary table, usually we flush this table completely
+     * before doing this import, as it is a delta file and does not
+     * have any relation to previous files.
+     * 
+     * @return bool true or false depending on if the import was a live import or not
+     */
+    public function import($flush = true) {
+        global $DB;
+        $importtable = $this->import_temp_tablename;
+        
+        if ($flush) {
+            mtrace(get_string('import:flushentries', 'local_xmlsync', $importtable) . "\n");
+
+            $DB->delete_records($importtable);
+        }
+
+        mtrace(get_string('importingstart', 'local_xmlsync', $importtable) . "\n");
+        $reader = $this->reader;  // Shorthand.
+
+        // Ensure we have the right top-level node.
+        $reader->read();
+        if($reader->name != self::XMLROWSET) {
+            //Moodle task logging will catch this and auto backoff or try again
+            throw new moodle_exception("The xml import document is not well formed and does not start with the top level node "+self::XMLROWSET);
+        }
+
+        // Parse time and convert to Unix timestamp.
+        $sourcetimestamp = (new \DateTimeImmutable($reader->getAttribute("timestamp")))->getTimestamp();
+
+        $metadata = array(
+            "sourcefile" => $reader->getAttribute("sourcefile"),
+            "sourcetimestamp" => $sourcetimestamp,
+        );
+        $importcount = 0;
+
+        // Check for stale file import: warn, but continue processing.
+        $stalethreshold = get_config('local_xmlsync', 'stale_threshold'); // Difference in seconds.
+        $now = (new \DateTimeImmutable('now'))->getTimestamp();
+        $filedelta = ($now - $sourcetimestamp); // Difference in seconds.
+        if ($filedelta > $stalethreshold) {
+            $filename = get_string('import:filename', 'local_xmlsync', $this->filename);
+            local_xmlsync_warn_import(
+                get_string('import:stalefile', 'local_xmlsync')
+                . "\n\n"
+                . $filename
+                . "\n"
+                . get_string('import:stalefile_timestamp', 'local_xmlsync', $reader->getAttribute("timestamp"))
+                . "\n",
+                get_string('import:stalemailsubject', 'local_xmlsync')
+            );
+        }
+
+        // Check for last timestamp match: skip processing if equal.
+        if ($this->lastsourcetimestamp) {
+            if ($this->lastsourcetimestamp == $sourcetimestamp) {
+                echo get_string('warning:timestampmatch', 'local_xmlsync') . "\n";
+                return false;
+            }
+        }
+
+        $to_import = [];//bulk imports
+        $batchsize = get_config('local_xmlsync', 'import_batch_threshold');
+        if(!$batchsize) {
+            $batchsize = self::BATCH_COUNT;
+        }
+        $batch_count = 0;
+        // Traverse the XML document, looking for rows and a rowcount at the end.
+        while ($reader->read()) {
+            // Parse from element start tags.
+            if ($reader->nodeType == \XMLReader::ELEMENT) {
+                if ($reader->name == self::XMLROW) {
+                    $rowdata = array();
+                    $rownode = $reader->expand();
+                    foreach (array_keys($this->rowmapping) as $xmlfield) {
+                        $this->import_rowfield($rowdata, $rownode, $xmlfield);
+                    }
+
+                    $batch_count++;
+                    $importcount++;
+                    $to_import[] = $rowdata;
+                    if($batch_count > $batchsize) {
+                        $DB->insert_records($importtable, $to_import);
+                        $to_import = [];
+                        $batch_count = 0;
+                    }
+
+
+                } else if ($reader->name == self::XMLROWCOUNT) {
+                    $metadata["rowcount"] = (int) $reader->readString();
+                }
+                else {
+
+                    //throw new moodle_exception("Unknown element in the xml document " . $reader->name);
+                }
+            }
+        }
+        /**
+         * Capture any remaining import records left over to import
+         */
+        if(count($to_import) > 0) {
+            $DB->insert_records($importtable, $to_import);
+            $to_import = [];
+            $batch_count = 0;
+        }
+
+        // Ensure imported row count matches expected tally.
+        if($importcount != $metadata["rowcount"]) {
+            throw new moodle_exception("Row count mismatch: imported {$importcount} rows, expected {$metadata["rowcount"]} rows.");
+        }
+
+
+
+        $metadata['importcount'] = $importcount;
+        $metadata['importedtime'] = (new \DateTimeImmutable('now'))->getTimestamp();
+        ksort($metadata);
+
+        $counts = $this->count_import_types($importtable);
+        // Ensure imported row count matches expected tally.
+        if($counts->totalcount != $metadata["rowcount"]) {
+            throw new moodle_exception("Row count mismatch: after import we had {$counts->totalcount} rows in the database, expected {$metadata["rowcount"]} rows.");
+        }
+        mtrace(get_string('import:sanitycheck', 'local_xmlsync'));
+        $this->sanity_check_import_table($importtable);
+
+        $counts->importcount = $importcount;
+        mtrace(get_string('import:rowcount', 'local_xmlsync', $counts) . "\n");
+        return true;
+    }
+
+    protected function count_import_types($tablename) {
+        global $DB;
+        $result = new stdClass();
+        $result->totalcount = $DB->count_records($tablename);
+        $result->updatecount = $DB->count_records($tablename, array('action' => self::ACTION_UPDATE));
+        $result->deletecount = $DB->count_records($tablename, array('action' => self::ACTION_DELETE));
+        return $result;
+    }
+
+    /**
+     * Insert XML value into row data, mapping to table column keys.
+     *
+     * @param array &$rowdata Array to gather field values.
+     * @param \DOMNode $node
+     * @param string $xmlfield
+     * @return void
+     */
+    public function import_rowfield(&$rowdata, $node, $xmlfield) {
+        $columnname = $this->rowmapping[$xmlfield];
+        $nodes = $node->getElementsByTagName($xmlfield);
+        if($nodes->length == 0) {
+            $nodevalue = null;//No value contained in the db
+        }else {
+            $nodevalue = $nodes[0]->nodeValue;
+        }
+        
+
+        if (substr_compare($columnname, "_dt", -strlen("_dt")) == 0) {
+            // Special handling for timestamps.
+            $nodevalue = (int) $nodevalue;
+        }
+
+        $nodevale = $this->validate_parameter($nodevalue, $columnname);
+
+        $rowdata[$columnname] = $nodevalue;
+    }
+
+    /**
+     * Allow subclasses to do custom validation/handling of a rowdata parameter if necessary
+     * @param mixed $nodevalue 
+     * @param mixed $columname 
+     * @return void 
+     */
+    public function validate_parameter($nodevalue, $columname) {
+        return $nodevalue;
+    }
+  
+    /**
+     * Helper: get a specific element from within a row body.
+     *
+     * Assumes unique element names in a row.
+     *
+     * @param \DOMNode $node
+     * @param string $xmlfield
+     * @return mixed
+     */
+    public function get_row_element($node, $xmlfield) {
+        return($node->getElementsByTagName($xmlfield)[0]->nodeValue);
+    }
+
+}

--- a/local/xmlsync/classes/import/course_importer.php
+++ b/local/xmlsync/classes/import/course_importer.php
@@ -1,0 +1,103 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * XML course import task
+ *
+ * @package    local_xmlsync
+ * @author     David Thompson <david.thompson@catalyst.net.nz>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_xmlsync\import;
+use xmldb_table;
+defined('MOODLE_INTERNAL') || die();
+
+
+class course_importer extends base_importer {
+
+    public $filename = 'moodle_crs.xml';
+
+    public $import_temp_tablename = 'local_xmlsync_crsimport_tmp';
+
+    public $import_main_tablename = 'local_xmlsync_crsimport';
+
+    /**
+     * Mapping from incoming XML field names to database column names.
+     * Note: ACTION is handled separately.
+     */
+    public $rowmapping = array(
+        'COURSE_IDNUMBER'   => 'course_idnumber',
+        'COURSE_FULLNAME'   => 'course_fullname',
+        'COURSE_SHORTNAME'  => 'course_shortname',
+        'COURSE_TEMPLATE'   => 'course_template',
+        'COURSE_VISIBILITY' => 'course_visibility',
+        'ACTION'            => 'action',
+    );
+
+    public function get_records_to_create($importtable, $maintable)
+    {
+        global $DB;
+        $params = array(self::ACTION_UPDATE);
+        $sql = "
+            SELECT import.*
+              FROM {{$importtable}} import
+         LEFT JOIN {{$maintable}} main
+                ON main.course_idnumber = import.course_idnumber
+             WHERE main.id IS NULL
+               AND import.action = ?";
+        $result = $DB->get_records_sql($sql, $params);
+        return $result;
+    }
+
+    public function get_records_to_delete($importtable, $maintable)
+    {
+         global $DB;
+         $params = array(self::ACTION_DELETE);
+         $sql = "
+            SELECT main.id
+              FROM {{$importtable}} import
+        INNER JOIN {{$maintable}} main
+                ON main.course_idnumber = import.course_idnumber
+             WHERE import.action = ?
+         ";
+        return $DB->get_records_sql($sql, $params);
+    }
+
+    public function get_records_to_update($importtable, $maintable)
+    {
+        global $DB;
+        //Get list of fields to import from the import table
+        //We also use the wheresql to only get records that have
+        //actually effectively changed in any way - by checking
+        //that any of the fields is actually != to the main table
+        //You can see we return with the main table records id
+        //so these returned records can go straight into an
+        //update_record call
+        list($selectsql, $wheresql) = $this->get_update_sql_helpers($importtable, $maintable);
+        $params = array(self::ACTION_UPDATE);
+        $sql = "
+            SELECT main.id, {$selectsql}
+              FROM {{$importtable}} import
+        INNER JOIN {{$maintable}} main
+                ON main.course_idnumber = import.course_idnumber
+             WHERE import.action = ?
+             AND ( {$wheresql} )
+        ";
+        return $DB->get_records_sql($sql, $params);
+    }
+}

--- a/local/xmlsync/classes/import/course_importer.php
+++ b/local/xmlsync/classes/import/course_importer.php
@@ -96,7 +96,6 @@ class course_importer extends base_importer {
         INNER JOIN {{$maintable}} main
                 ON main.course_idnumber = import.course_idnumber
              WHERE import.action = ?
-             AND ( {$wheresql} )
         ";
         return $DB->get_records_sql($sql, $params);
     }

--- a/local/xmlsync/classes/import/enrol_importer.php
+++ b/local/xmlsync/classes/import/enrol_importer.php
@@ -100,7 +100,6 @@ class enrol_importer extends base_importer {
         INNER JOIN {{$maintable}} main
                 ON main.course_idnumber = import.course_idnumber AND main.user_idnumber = import.user_idnumber
              WHERE import.action = ?
-             AND ( {$wheresql} )
         ";
         return $DB->get_records_sql($sql, $params);
     }

--- a/local/xmlsync/classes/import/enrol_importer.php
+++ b/local/xmlsync/classes/import/enrol_importer.php
@@ -1,0 +1,121 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * XML enrol import task
+ *
+ * @package    local_xmlsync
+ * @author     David Thompson <david.thompson@catalyst.net.nz>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_xmlsync\import;
+defined('MOODLE_INTERNAL') || die();
+
+
+class enrol_importer extends base_importer {
+    
+    public $filename = 'moodle_enr.xml';
+
+    public $import_temp_tablename = 'local_xmlsync_enrlimport_tmp';
+
+    public $import_main_tablename = 'local_xmlsync_enrlimport';
+    /**
+     * Mapping from incoming XML field names to database column names.
+     * Note: ACTION is handled separately.
+     */
+    public $rowmapping = array(
+        'COURSE_IDNUMBER'    => 'course_idnumber',
+        'USERNAME'           => 'username',
+        'ROLE_SHORTNAME'     => 'role_shortname',
+        'USER_IDNUMBER'      => 'user_idnumber',
+        'ETHNIC_CODES'       => 'ethnic_codes',
+        'ETHNIC_DESCRIPTION' => 'ethnic_description',
+        'RESIDENCY'          => 'residency',
+        'UNDER_25'           => 'under_25',
+        'MAORI'              => 'maori',
+        'PACIFIC'            => 'pacific',
+        'INTERNATIONAL'      => 'international',
+        'ACTION'             => 'action',
+    );
+
+    public function get_records_to_create($importtable, $maintable)
+    {
+        global $DB;
+        $params = array(self::ACTION_UPDATE);
+        $sql = "
+            SELECT import.*
+              FROM {{$importtable}} import
+         LEFT JOIN {{$maintable}} main
+                ON main.course_idnumber = import.course_idnumber AND main.user_idnumber = import.user_idnumber
+             WHERE main.id IS NULL
+               AND import.action = ?";
+        $result = $DB->get_records_sql($sql, $params);
+        return $result;
+    }
+
+    public function get_records_to_delete($importtable, $maintable)
+    {
+         global $DB;
+         $params = array(self::ACTION_DELETE);
+         $sql = "
+            SELECT main.id
+              FROM {{$importtable}} import
+        INNER JOIN {{$maintable}} main
+                ON main.course_idnumber = import.course_idnumber AND main.user_idnumber = import.user_idnumber
+             WHERE import.action = ?
+         ";
+        return $DB->get_records_sql($sql, $params);
+    }
+
+    public function get_records_to_update($importtable, $maintable)
+    {
+        global $DB;
+        //Get list of fields to import from the import table
+        //We also use the wheresql to only get records that have
+        //actually effectively changed in any way - by checking
+        //that any of the fields is actually != to the main table
+        //You can see we return with the main table records id
+        //so these returned records can go straight into an
+        //update_record call
+        list($selectsql, $wheresql) = $this->get_update_sql_helpers($importtable, $maintable);
+        $params = array(self::ACTION_UPDATE);
+        $sql = "
+            SELECT main.id, {$selectsql}
+              FROM {{$importtable}} import
+        INNER JOIN {{$maintable}} main
+                ON main.course_idnumber = import.course_idnumber AND main.user_idnumber = import.user_idnumber
+             WHERE import.action = ?
+             AND ( {$wheresql} )
+        ";
+        return $DB->get_records_sql($sql, $params);
+    }
+
+    public function sanity_check_import_table($importtable) {
+        global $DB;
+        $idsql = $DB->sql_concat_join("' '", array('course_idnumber', 'user_idnumber'));
+        $sql = "SELECT * FROM (SELECT $idsql AS id, count(id) as appearances, course_idnumber, user_idnumber
+                  FROM {{$importtable}}
+              GROUP BY course_idnumber, user_idnumber) as dupes
+                 WHERE dupes.appearances > 1";
+        $dupes = $DB->get_records_sql($sql);
+        foreach($dupes as $dupe) {
+            mtrace("user idnumber, course idnumber combination appeared more than once - user_idnumber:$dupe->user_idnumber, course_idnumber: $dupe->course_idnumber, total appearances $dupe->appearances");
+        }
+    }
+
+}

--- a/local/xmlsync/classes/import/user_importer.php
+++ b/local/xmlsync/classes/import/user_importer.php
@@ -1,0 +1,145 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * XML user import task
+ *
+ * @package    local_xmlsync
+ * @author     David Thompson <david.thompson@catalyst.net.nz>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_xmlsync\import;
+defined('MOODLE_INTERNAL') || die();
+
+
+class user_importer extends base_importer {
+    public $filename = 'moodle_per.xml';
+
+    public $import_temp_tablename = 'local_xmlsync_userimport_tmp';
+
+    public $import_main_tablename = 'local_xmlsync_userimport';
+
+    /**
+     * Import count from last import, if any.
+     * Set during task initialisation.
+     * @var int|null
+     */
+    public $lastimportcount = null;
+
+    /**
+     * Source timestamp from last import, if any.
+     * Set during task initialisation.
+     * @var int|null
+     */
+    public $lastsourcetimestamp = null;
+
+    /**
+     * Mapping from incoming XML field names to database column names.
+     * Note: ACTION is handled separately.
+     */
+    public $rowmapping = array(
+        'USERNAME'      => 'username',
+        'PASSWORD'      => 'password',
+        'EMAIL'         => 'email',
+        'FIRSTNAME'     => 'firstname',
+        'LASTNAME'      => 'lastname',
+        'CITY'          => 'city',
+        'COUNTRY'       => 'country',
+        'LANG'          => 'lang',
+        'DESCRIPTION'   => 'description',
+        'IDNUMBER'      => 'idnumber',
+        'INSTITUTION'   => 'institution',
+        'DEPARTMENT'    => 'department',
+        'PHONE1'        => 'phone1',
+        'PHONE2'        => 'phone2',
+        'MIDDLENAME'    => 'middlename',
+        'ACTIVATION_DT' => 'activation_dt',
+        'DEACTIVATE_DT' => 'deactivate_dt',
+        'ARCHIVE_DT'    => 'archive_dt',
+        'PURGE_DT'      => 'purge_dt',
+        'ACTION'        => 'action',
+    );
+
+    public function get_records_to_create($importtable, $maintable)
+    {
+        global $DB;
+        $params = array(self::ACTION_UPDATE);
+        $sql = "
+            SELECT import.*
+              FROM {{$importtable}} import
+         LEFT JOIN {{$maintable}} main
+                ON main.idnumber = import.idnumber
+             WHERE main.id IS NULL
+               AND import.action = ?";
+        $result = $DB->get_records_sql($sql, $params);
+        return $result;
+    }
+
+    public function get_records_to_delete($importtable, $maintable)
+    {
+         global $DB;
+         $params = array(self::ACTION_DELETE);
+         $sql = "
+            SELECT main.id
+              FROM {{$importtable}} import
+        INNER JOIN {{$maintable}} main
+                ON main.idnumber = import.idnumber
+             WHERE import.action = ?
+         ";
+        return $DB->get_records_sql($sql, $params);
+    }
+
+    public function get_records_to_update($importtable, $maintable)
+    {
+        global $DB;
+        //Get list of fields to import from the import table
+        //We also use the wheresql to only get records that have
+        //actually effectively changed in any way - by checking
+        //that any of the fields is actually != to the main table
+        //You can see we return with the main table records id
+        //so these returned records can go straight into an
+        //update_record call
+        list($selectsql, $wheresql) = $this->get_update_sql_helpers($importtable, $maintable);
+        $params = array(self::ACTION_UPDATE);
+        $sql = "
+            SELECT main.id, {$selectsql}
+              FROM {{$importtable}} import
+        INNER JOIN {{$maintable}} main
+                ON main.idnumber = import.idnumber
+             WHERE import.action = ?
+             AND ( {$wheresql} )
+        ";
+        return $DB->get_records_sql($sql, $params);
+    }
+
+    /**
+     * For users, we really want a null in the password field if none is provided.
+     * @param mixed $nodevalue 
+     * @param mixed $columname 
+     * @return void 
+     */
+    public function validate_parameter($nodevalue, $columname)
+    {
+        if($columname == 'password') {
+            if(!isset($nodevalue) || $nodevalue == '') {
+                $nodevalue = null;
+            }
+        }
+        return $nodevalue;
+    }
+}

--- a/local/xmlsync/classes/import/user_importer.php
+++ b/local/xmlsync/classes/import/user_importer.php
@@ -122,7 +122,6 @@ class user_importer extends base_importer {
         INNER JOIN {{$maintable}} main
                 ON main.idnumber = import.idnumber
              WHERE import.action = ?
-             AND ( {$wheresql} )
         ";
         return $DB->get_records_sql($sql, $params);
     }

--- a/local/xmlsync/classes/task/course_import_task.php
+++ b/local/xmlsync/classes/task/course_import_task.php
@@ -1,0 +1,59 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * XML course import task
+ *
+ * @package    local_xmlsync
+ * @author     David Thompson <david.thompson@catalyst.net.nz>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_xmlsync\task;
+defined('MOODLE_INTERNAL') || die();
+
+class course_import_task extends \core\task\scheduled_task {
+    /**
+     * Task description.
+     *
+     * @return string
+     */
+    public function get_name() : string {
+        return get_string('courseimport:crontask', 'local_xmlsync');
+    }
+
+    /**
+     * Execute import task.
+     *
+     * Import data from XML into inactive replica table.
+     * If the import is successful, set replica to active.
+     *
+     * @return void
+     */
+    public function execute() : void {
+        global $CFG;
+
+        require_once($CFG->dirroot . '/local/xmlsync/locallib.php');
+
+        $importer = new \local_xmlsync\import\course_importer();
+        echo get_string('courseimport:starttask', 'local_xmlsync') . "\n";
+        $importer->import();
+        $importer->sync();
+        echo get_string('courseimport:completetask', 'local_xmlsync') . "\n";
+    }
+
+}

--- a/local/xmlsync/classes/task/enrol_import_task.php
+++ b/local/xmlsync/classes/task/enrol_import_task.php
@@ -1,0 +1,59 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * XML enrol import task
+ *
+ * @package    local_xmlsync
+ * @author     David Thompson <david.thompson@catalyst.net.nz>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_xmlsync\task;
+defined('MOODLE_INTERNAL') || die();
+
+class enrol_import_task extends \core\task\scheduled_task {
+    /**
+     * Task description.
+     *
+     * @return string
+     */
+    public function get_name() : string {
+        return get_string('enrolimport:crontask', 'local_xmlsync');
+    }
+
+    /**
+     * Execute import task.
+     *
+     * Import data from XML into inactive replica table.
+     * If the import is successful, set replica to active.
+     *
+     * @return void
+     */
+    public function execute() : void {
+        global $CFG;
+
+        require_once($CFG->dirroot . '/local/xmlsync/locallib.php');
+
+        $importer = new \local_xmlsync\import\enrol_importer();
+        echo get_string('enrolimport:starttask', 'local_xmlsync') . "\n";
+        $importer->import();
+        $importer->sync();
+        echo get_string('enrolimport:completetask', 'local_xmlsync') . "\n";
+    }
+
+}

--- a/local/xmlsync/classes/task/user_import_task.php
+++ b/local/xmlsync/classes/task/user_import_task.php
@@ -1,0 +1,60 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * XML user import task
+ *
+ * @package    local_xmlsync
+ * @author     David Thompson <david.thompson@catalyst.net.nz>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_xmlsync\task;
+defined('MOODLE_INTERNAL') || die();
+
+class user_import_task extends \core\task\scheduled_task {
+    /**
+     * Task description.
+     *
+     * @return string
+     */
+    public function get_name() : string {
+        return get_string('userimport:crontask', 'local_xmlsync');
+    }
+
+    /**
+     * Execute import task.
+     *
+     * Import data from XML into inactive replica table.
+     * If the import is successful, set replica to active.
+     *
+     * @return void
+     */
+    public function execute() : void {
+        global $CFG;
+
+        require_once($CFG->dirroot . '/local/xmlsync/locallib.php');
+
+        $importer = new \local_xmlsync\import\user_importer();
+        echo get_string('userimport:starttask', 'local_xmlsync') . "\n";
+        $importer->import();
+        $importer->sync();
+        echo get_string('userimport:completetask', 'local_xmlsync') . "\n";
+
+    }
+
+}

--- a/local/xmlsync/classes/util.php
+++ b/local/xmlsync/classes/util.php
@@ -66,13 +66,14 @@ class util {
      */
     public static function enrol_database_course_update_hook(&$course) {
         global $DB;
-        return false;//TODO we need to update the course visibility here
         $select = $DB->sql_like('course_idnumber', ':idnum', false); // Case insensitive.
         $params = array('idnum' => $course->idnumber);
         $matchingrecord = $DB->get_record_select('local_xmlsync_crsimport', $select, $params);
-        if ($matchingrecord) {
+        if ($matchingrecord && $course->visible != $matchingrecord->course_visibility) {
             $course->visible = $matchingrecord->course_visibility;
+            $DB->update_record('course', $course);
         }
+
     }
 
     /**

--- a/local/xmlsync/classes/util.php
+++ b/local/xmlsync/classes/util.php
@@ -1,0 +1,151 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Utility functions that don't fit elsewhere.
+ *
+ * @package    local_xmlsync
+ * @author     David Thompson <david.thompson@catalyst.net.nz>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_xmlsync;
+
+defined('MOODLE_INTERNAL') || die();
+
+class util {
+    /**
+     * Hook for enrol_database to set course visibility.
+     *
+     * If an xmlsync record with a matching idnumber is found, set course visibility accordingly.
+     *
+     * Required core change injected into enrol/database/lib.php sync_courses:
+     *     \local_xmlsync\util::enrol_database_course_hook($course);
+     *
+     * WR#371794
+     *
+     * @param stdClass $course
+     * @return void
+     */
+    public static function enrol_database_course_hook(&$course) {
+        global $DB;
+        $select = $DB->sql_like('course_idnumber', ':idnum', false); // Case insensitive.
+        $params = array('idnum' => $course->idnumber);
+        $matchingrecord = $DB->get_record_select('local_xmlsync_crsimport', $select, $params);
+        if ($matchingrecord) {
+            $course->visible = $matchingrecord->course_visibility;
+        }
+    }
+
+    /**
+     * Hook for enrol_database to set course visibility.
+     *
+     * If an xmlsync record with a matching idnumber is found, set course visibility accordingly.
+     *
+     * Required core change injected into enrol/database/lib.php sync_courses:
+     *     \local_xmlsync\util::enrol_database_course_hook($course);
+     *
+     * WR#371794
+     *
+     * @param stdClass $course
+     * @return void
+     */
+    public static function enrol_database_course_update_hook(&$course) {
+        global $DB;
+        return false;//TODO we need to update the course visibility here
+        $select = $DB->sql_like('course_idnumber', ':idnum', false); // Case insensitive.
+        $params = array('idnum' => $course->idnumber);
+        $matchingrecord = $DB->get_record_select('local_xmlsync_crsimport', $select, $params);
+        if ($matchingrecord) {
+            $course->visible = $matchingrecord->course_visibility;
+        }
+    }
+
+    /**
+     * Hook for enrol_database: Check whether course with idnumber has entry in course import.
+     *
+     * WR#371793
+     *
+     * @param string $idnumber
+     * @return boolean
+     */
+    public static function enrol_database_template_check($idnumber) : bool {
+        global $DB;
+        $select = $DB->sql_like('course_idnumber', ':idnum', false); // Case insensitive.
+        $params = array('idnum' => $idnumber);
+        $matchingrecord = $DB->get_record_select('local_xmlsync_crsimport', $select, $params);
+
+        if ($matchingrecord && $matchingrecord->course_template != '') {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Hook for enrol_database: clone course from template.
+     *
+     * If:
+     * - an xmlsync record with a matching idnumber is found
+     * - its template field is a valid course idnumber
+     * Then clone the template course content into the new course, minus user data.
+     *
+     * Required core change injected into enrol/database/lib.php sync_courses:
+     *     \local_xmlsync\util::enrol_database_template_hook($course);
+     *
+     * WR#371793
+     *
+     * @param stdClass $course
+     * @return void
+     */
+    public static function enrol_database_template_hook($course) {
+        global $CFG, $DB;
+        require_once($CFG->dirroot . '/backup/util/includes/backup_includes.php');
+        require_once($CFG->dirroot . '/backup/util/includes/restore_includes.php');
+        $select = $DB->sql_like('course_idnumber', ':idnum', false); // Case insensitive.
+        $params = array('idnum' => $course->idnumber);
+        $matchingrecord = $DB->get_record_select('local_xmlsync_crsimport', $select, $params);
+        if ($matchingrecord) {
+            $templatecourse = $DB->get_record('course', array('idnumber' => $matchingrecord->course_template));
+
+            if ($templatecourse) {
+                echo "Found matching record and template course.\n";
+                echo "Cloning from '{$templatecourse->fullname}' into '{$course->fullname}':\n";
+
+                // Make a fake course copy form.
+                $dummyform = array(
+                    'courseid' => $templatecourse->id,  // Copying from here.
+                    'fullname' => $course->fullname,
+                    'shortname' => $course->shortname,
+                    'category' => $course->category,
+                    'visible' => $course->visible,
+                    'startdate' => $course->startdate,
+                    'enddate' => $course->enddate,
+                    'idnumber' => $course->idnumber,
+                    'userdata' => '0',  // Do not copy user data.
+                    'role_1' => '1', // Keep managers?
+                    'role_5' => '0', // Drop students.
+                );
+                // Cast to stdClass object.
+                $mdata = (object) $dummyform;
+
+                $backupcopy = new \core_backup\copy\copy($mdata);
+                $backupcopy->create_copy();
+            }
+        }
+    }
+}

--- a/local/xmlsync/db/install.xml
+++ b/local/xmlsync/db/install.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<XMLDB PATH="local/xmlsync/db" VERSION="20220504" COMMENT="XMLDB file for Moodle local/xmlsync"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
+>
+  <TABLES>
+    <TABLE NAME="local_xmlsync_userimport" COMMENT="Master table of imported delta user files">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="username" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="password" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="email" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="firstname" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="lastname" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="city" TYPE="char" LENGTH="120" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="country" TYPE="char" LENGTH="2" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="lang" TYPE="char" LENGTH="2" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="description" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="idnumber" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="department" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="phone1" TYPE="char" LENGTH="20" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="phone2" TYPE="char" LENGTH="20" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="middlename" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="activation_dt" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="deactivate_dt" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="archive_dt" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="purge_dt" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+    </TABLE>
+    <TABLE NAME="local_xmlsync_userimport_tmp" COMMENT="Contains the delta file being operated on">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="username" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="password" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="email" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="firstname" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="lastname" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="city" TYPE="char" LENGTH="120" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="country" TYPE="char" LENGTH="2" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="lang" TYPE="char" LENGTH="2" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="description" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="idnumber" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="department" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="phone1" TYPE="char" LENGTH="20" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="phone2" TYPE="char" LENGTH="20" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="middlename" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="activation_dt" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="deactivate_dt" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="archive_dt" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="purge_dt" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="action" TYPE="char" LENGTH="2" NOTNULL="true" DEFAULT="?" SEQUENCE="false" COMMENT="Action to take U (Update), D (Delete)"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+    </TABLE>
+    <TABLE NAME="local_xmlsync_enrlimport" COMMENT="Master table of all imported enrolment delta files">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="course_idnumber" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="username" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="role_shortname" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="user_idnumber" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="ethnic_codes" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false" COMMENT="Ethnicity codes. Three-digit numbers, semicolon-separated."/>
+        <FIELD NAME="ethnic_description" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="Ethnicity descriptions. Human-readable, semicolon-separated."/>
+        <FIELD NAME="residency" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="under_25" TYPE="char" LENGTH="1" NOTNULL="true" DEFAULT="?" SEQUENCE="false" COMMENT="Y/N"/>
+        <FIELD NAME="maori" TYPE="char" LENGTH="1" NOTNULL="true" DEFAULT="?" SEQUENCE="false" COMMENT="Y/N"/>
+        <FIELD NAME="pacific" TYPE="char" LENGTH="1" NOTNULL="true" DEFAULT="?" SEQUENCE="false" COMMENT="Y/N"/>
+        <FIELD NAME="international" TYPE="char" LENGTH="1" NOTNULL="true" DEFAULT="?" SEQUENCE="false" COMMENT="Y/N"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+    </TABLE>
+    <TABLE NAME="local_xmlsync_enrlimport_tmp" COMMENT="Inflight import table">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="course_idnumber" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="username" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="role_shortname" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="user_idnumber" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="ethnic_codes" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false" COMMENT="Ethnicity codes. Three-digit numbers, semicolon-separated."/>
+        <FIELD NAME="ethnic_description" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="Ethnicity descriptions. Human-readable, semicolon-separated."/>
+        <FIELD NAME="residency" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="under_25" TYPE="char" LENGTH="1" NOTNULL="true" DEFAULT="?" SEQUENCE="false" COMMENT="Y/N"/>
+        <FIELD NAME="maori" TYPE="char" LENGTH="1" NOTNULL="true" DEFAULT="?" SEQUENCE="false" COMMENT="Y/N"/>
+        <FIELD NAME="pacific" TYPE="char" LENGTH="1" NOTNULL="true" DEFAULT="?" SEQUENCE="false" COMMENT="Y/N"/>
+        <FIELD NAME="international" TYPE="char" LENGTH="1" NOTNULL="true" DEFAULT="?" SEQUENCE="false" COMMENT="Y/N"/>
+        <FIELD NAME="action" TYPE="char" LENGTH="2" NOTNULL="true" DEFAULT="?" SEQUENCE="false" COMMENT="Action to take U (Update), D (Delete)"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+    </TABLE>
+    <TABLE NAME="local_xmlsync_crsimport" COMMENT="Master table of all imported course delta files">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="course_idnumber" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="course_fullname" TYPE="char" LENGTH="254" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="course_shortname" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="course_template" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false" COMMENT="Assumed same characteristics as course_idnumber"/>
+        <FIELD NAME="course_visibility" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="1" SEQUENCE="false" COMMENT="Assuming boolean per {course}.visible."/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+    </TABLE>
+    <TABLE NAME="local_xmlsync_crsimport_tmp" COMMENT="Inflight import of course data">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="course_idnumber" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="course_fullname" TYPE="char" LENGTH="254" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="course_shortname" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="course_template" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false" COMMENT="Assumed same characteristics as course_idnumber"/>
+        <FIELD NAME="course_visibility" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="1" SEQUENCE="false" COMMENT="Assuming boolean per {course}.visible."/>
+        <FIELD NAME="action" TYPE="char" LENGTH="2" NOTNULL="true" DEFAULT="?" SEQUENCE="false" COMMENT="Action to take U (Update), D (Delete)"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+      </KEYS>
+    </TABLE>
+  </TABLES>
+</XMLDB>

--- a/local/xmlsync/db/tasks.php
+++ b/local/xmlsync/db/tasks.php
@@ -1,0 +1,56 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * XML Import task definitions
+ *
+ * @package    local_xmlsync
+ * @author     David Thompson <david.thompson@catalyst.net.nz>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+$tasks = [
+    [
+        'classname' => 'local_xmlsync\task\course_import_task',
+        'blocking' => 0,
+        'minute' => '*',
+        'hour' => '*',
+        'day' => '*',
+        'month' => '*',
+        'dayofweek' => '*'
+    ],
+    [
+        'classname' => 'local_xmlsync\task\enrol_import_task',
+        'blocking' => 0,
+        'minute' => '*',
+        'hour' => '*',
+        'day' => '*',
+        'month' => '*',
+        'dayofweek' => '*'
+    ],
+    [
+        'classname' => 'local_xmlsync\task\user_import_task',
+        'blocking' => 0,
+        'minute' => '*',
+        'hour' => '*',
+        'day' => '*',
+        'month' => '*',
+        'dayofweek' => '*'
+    ],
+];

--- a/local/xmlsync/db/upgrade.php
+++ b/local/xmlsync/db/upgrade.php
@@ -1,0 +1,380 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Database upgrades
+ *
+ * @package    local_xmlsync
+ * @author     David Thompson <david.thompson@catalyst.net.nz>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+function xmldb_local_xmlsync_upgrade($oldversion) {
+    global $DB;
+    $dbman = $DB->get_manager();
+
+    if ($oldversion < 2021112500) {
+
+        // Define local_xmlsync_enrolimport_X replica tables to be created.
+        $replicas = array(
+            new xmldb_table('local_xmlsync_enrolimport_a'),
+            new xmldb_table('local_xmlsync_enrolimport_b'),
+        );
+
+        foreach ($replicas as $table) {
+            // Adding fields to table local_xmlsync_enrolimport_X replica.
+            $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+            $table->add_field('course_idnumber', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+            $table->add_field('username', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+            $table->add_field('role_shortname', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+            $table->add_field('user_idnumber', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+            $table->add_field('visa_nsi', XMLDB_TYPE_CHAR, '3', null, XMLDB_NOTNULL, null, null);
+            $table->add_field('ethnic_codes', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+            $table->add_field('ethnic_description', XMLDB_TYPE_CHAR, '255', null, null, null, null);
+            $table->add_field('residency', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+            $table->add_field('under_25', XMLDB_TYPE_CHAR, '1', null, XMLDB_NOTNULL, null, '?');
+            $table->add_field('maori', XMLDB_TYPE_CHAR, '1', null, XMLDB_NOTNULL, null, '?');
+            $table->add_field('pacific', XMLDB_TYPE_CHAR, '1', null, XMLDB_NOTNULL, null, '?');
+            $table->add_field('international', XMLDB_TYPE_CHAR, '1', null, XMLDB_NOTNULL, null, '?');
+
+            // Adding keys to table local_xmlsync_enrolimport_X replica.
+            $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+
+            // Conditionally launch create table for local_xmlsync_enrolimport_X replica.
+            if (!$dbman->table_exists($table)) {
+                $dbman->create_table($table);
+            }
+        }
+
+        // Xmlsync savepoint reached.
+        upgrade_plugin_savepoint(true, 2021112500, 'local', 'xmlsync');
+    }
+
+    if ($oldversion < 2021112600) {
+
+        // Define field visa_nsi to be dropped from local_xmlsync_enrolimport_X replicas.
+        $replicas = array(
+            new xmldb_table('local_xmlsync_enrolimport_a'),
+            new xmldb_table('local_xmlsync_enrolimport_b'),
+        );
+        $field = new xmldb_field('visa_nsi');
+
+        foreach ($replicas as $table) {
+            // Conditionally launch drop field visa_nsi.
+            if ($dbman->field_exists($table, $field)) {
+                $dbman->drop_field($table, $field);
+            }
+        }
+
+        // Xmlsync savepoint reached.
+        upgrade_plugin_savepoint(true, 2021112600, 'local', 'xmlsync');
+    }
+
+    if ($oldversion < 2021120102) {
+
+        // Define table local_xmlsync_crsimport to be created.
+        $table = new xmldb_table('local_xmlsync_crsimport');
+
+        // Adding fields to table local_xmlsync_crsimport_log.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('course_idnumber', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('course_fullname', XMLDB_TYPE_CHAR, '254', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('course_shortname', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('course_template', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('course_visibility', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1');
+
+        // Adding keys to table local_xmlsync_crsimport.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+
+        // Conditionally launch create table for local_xmlsync_crsimport.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Define table local_xmlsync_crsimport_log to be created.
+        $table = new xmldb_table('local_xmlsync_crsimport_log');
+
+        // Adding fields to table local_xmlsync_crsimport_log.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('rowaction', XMLDB_TYPE_CHAR, '1', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('rowprocessed', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('course_idnumber', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('course_fullname', XMLDB_TYPE_CHAR, '254', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('course_shortname', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('course_template', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('course_visibility', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1');
+
+        // Adding keys to table local_xmlsync_crsimport_log.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+
+        // Conditionally launch create table for local_xmlsync_crsimport_log.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Xmlsync savepoint reached.
+        upgrade_plugin_savepoint(true, 2021120102, 'local', 'xmlsync');
+    }
+    if ($oldversion < 2022050400) {
+
+        // Define table local_xmlsync_userimport_a to be dropped.
+        $table = new xmldb_table('local_xmlsync_userimport_a');
+
+        // Conditionally launch drop table for local_xmlsync_userimport_a.
+        if ($dbman->table_exists($table)) {
+            $dbman->drop_table($table);
+        }
+        $table = new xmldb_table('local_xmlsync_userimport_b');
+
+        // Conditionally launch drop table for local_xmlsync_userimport_b.
+        if ($dbman->table_exists($table)) {
+            $dbman->drop_table($table);
+        }
+        // Define table local_xmlsync_enrolimport_a to be dropped.
+        $table = new xmldb_table('local_xmlsync_enrolimport_a');
+
+        // Conditionally launch drop table for local_xmlsync_enrolimport_a.
+        if ($dbman->table_exists($table)) {
+            $dbman->drop_table($table);
+        }
+        // Define table local_xmlsync_enrolimport_b to be dropped.
+        $table = new xmldb_table('local_xmlsync_enrolimport_b');
+
+        // Conditionally launch drop table for local_xmlsync_enrolimport_b.
+        if ($dbman->table_exists($table)) {
+            $dbman->drop_table($table);
+        }
+
+        // Define table local_xmlsync_crsimport_log to be dropped.
+        $table = new xmldb_table('local_xmlsync_crsimport_log');
+
+        // Conditionally launch drop table for local_xmlsync_crsimport_log.
+        if ($dbman->table_exists($table)) {
+            $dbman->drop_table($table);
+        }
+
+        // Xmlsync savepoint reached.
+        upgrade_plugin_savepoint(true, 2022050400, 'local', 'xmlsync');
+    }
+
+    if ($oldversion < 2022050401) {
+
+        // Define table local_xmlsync_userimport to be created.
+        $table = new xmldb_table('local_xmlsync_userimport');
+
+        // Adding fields to table local_xmlsync_userimport.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('username', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('password', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('email', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('firstname', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('lastname', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('city', XMLDB_TYPE_CHAR, '120', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('country', XMLDB_TYPE_CHAR, '2', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('lang', XMLDB_TYPE_CHAR, '2', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('description', XMLDB_TYPE_TEXT, null, null, null, null, null);
+        $table->add_field('idnumber', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('department', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('phone1', XMLDB_TYPE_CHAR, '20', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('phone2', XMLDB_TYPE_CHAR, '20', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('middlename', XMLDB_TYPE_CHAR, '255', null, null, null, null);
+        $table->add_field('activation_dt', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('deactivate_dt', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('archive_dt', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('purge_dt', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+
+        // Adding keys to table local_xmlsync_userimport.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+
+        // Conditionally launch create table for local_xmlsync_userimport.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Define table local_xmlsync_userimport_tmp to be created.
+        $table = new xmldb_table('local_xmlsync_userimport_tmp');
+
+        // Adding fields to table local_xmlsync_userimport_tmp.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('username', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('password', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('email', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('firstname', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('lastname', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('city', XMLDB_TYPE_CHAR, '120', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('country', XMLDB_TYPE_CHAR, '2', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('lang', XMLDB_TYPE_CHAR, '2', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('description', XMLDB_TYPE_TEXT, null, null, null, null, null);
+        $table->add_field('idnumber', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('department', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('phone1', XMLDB_TYPE_CHAR, '20', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('phone2', XMLDB_TYPE_CHAR, '20', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('middlename', XMLDB_TYPE_CHAR, '255', null, null, null, null);
+        $table->add_field('activation_dt', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('deactivate_dt', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('archive_dt', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('purge_dt', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('action', XMLDB_TYPE_CHAR, '2', null, XMLDB_NOTNULL, null, '?');
+
+        // Adding keys to table local_xmlsync_userimport_tmp.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+
+        // Conditionally launch create table for local_xmlsync_userimport_tmp.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Define table local_xmlsync_enrlimport to be created.
+        $table = new xmldb_table('local_xmlsync_enrlimport');
+
+        // Adding fields to table local_xmlsync_enrlimport.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('course_idnumber', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('username', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('role_shortname', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('user_idnumber', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('ethnic_codes', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('ethnic_description', XMLDB_TYPE_CHAR, '255', null, null, null, null);
+        $table->add_field('residency', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('under_25', XMLDB_TYPE_CHAR, '1', null, XMLDB_NOTNULL, null, '?');
+        $table->add_field('maori', XMLDB_TYPE_CHAR, '1', null, XMLDB_NOTNULL, null, '?');
+        $table->add_field('pacific', XMLDB_TYPE_CHAR, '1', null, XMLDB_NOTNULL, null, '?');
+        $table->add_field('international', XMLDB_TYPE_CHAR, '1', null, XMLDB_NOTNULL, null, '?');
+
+        // Adding keys to table local_xmlsync_enrlimport.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+
+        // Conditionally launch create table for local_xmlsync_enrlimport.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Define table local_xmlsync_enrlimport_tmp to be created.
+        $table = new xmldb_table('local_xmlsync_enrlimport_tmp');
+
+        // Adding fields to table local_xmlsync_enrlimport_tmp.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('course_idnumber', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('username', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('role_shortname', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('user_idnumber', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('ethnic_codes', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('ethnic_description', XMLDB_TYPE_CHAR, '255', null, null, null, null);
+        $table->add_field('residency', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('under_25', XMLDB_TYPE_CHAR, '1', null, XMLDB_NOTNULL, null, '?');
+        $table->add_field('maori', XMLDB_TYPE_CHAR, '1', null, XMLDB_NOTNULL, null, '?');
+        $table->add_field('pacific', XMLDB_TYPE_CHAR, '1', null, XMLDB_NOTNULL, null, '?');
+        $table->add_field('international', XMLDB_TYPE_CHAR, '1', null, XMLDB_NOTNULL, null, '?');
+        $table->add_field('action', XMLDB_TYPE_CHAR, '2', null, XMLDB_NOTNULL, null, '?');
+
+        // Adding keys to table local_xmlsync_enrlimport_tmp.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+
+        // Conditionally launch create table for local_xmlsync_enrlimport_tmp.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Define table local_xmlsync_crsimport to be created.
+        $table = new xmldb_table('local_xmlsync_crsimport');
+
+        // Adding fields to table local_xmlsync_crsimport.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('course_idnumber', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('course_fullname', XMLDB_TYPE_CHAR, '254', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('course_shortname', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('course_template', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('course_visibility', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1');
+
+        // Adding keys to table local_xmlsync_crsimport.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+
+        // Conditionally launch create table for local_xmlsync_crsimport.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Define table local_xmlsync_crsimport_tmp to be created.
+        $table = new xmldb_table('local_xmlsync_crsimport_tmp');
+
+        // Adding fields to table local_xmlsync_crsimport_tmp.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('course_idnumber', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('course_fullname', XMLDB_TYPE_CHAR, '254', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('course_shortname', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('course_template', XMLDB_TYPE_CHAR, '100', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('course_visibility', XMLDB_TYPE_INTEGER, '1', null, XMLDB_NOTNULL, null, '1');
+        $table->add_field('action', XMLDB_TYPE_CHAR, '2', null, XMLDB_NOTNULL, null, '?');
+
+        // Adding keys to table local_xmlsync_crsimport_tmp.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+
+        // Conditionally launch create table for local_xmlsync_crsimport_tmp.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Xmlsync savepoint reached.
+        upgrade_plugin_savepoint(true, 2022050401, 'local', 'xmlsync');
+    }
+    if ($oldversion < 2022050402) {
+
+        // Changing nullability of field course_visibility on table local_xmlsync_crsimport to null.
+        $table = new xmldb_table('local_xmlsync_crsimport');
+        $field = new xmldb_field('course_visibility', XMLDB_TYPE_INTEGER, '1', null, null, null, '1', 'course_template');
+
+        // Launch change of nullability for field course_visibility.
+        $dbman->change_field_notnull($table, $field);
+
+
+        // Changing nullability of field course_visibility on table local_xmlsync_crsimport_tmp to null.
+        $table = new xmldb_table('local_xmlsync_crsimport_tmp');
+        $field = new xmldb_field('course_visibility', XMLDB_TYPE_INTEGER, '1', null, null, null, '1', 'course_template');
+
+        // Launch change of nullability for field course_visibility.
+        $dbman->change_field_notnull($table, $field);
+
+        // Xmlsync savepoint reached.
+        upgrade_plugin_savepoint(true, 2022050402, 'local', 'xmlsync');
+    }
+    if ($oldversion < 2022050500) {
+
+        // Changing nullability of field password on table local_xmlsync_userimport to null.
+        $table = new xmldb_table('local_xmlsync_userimport');
+        $field = new xmldb_field('password', XMLDB_TYPE_CHAR, '255', null, null, null, null, 'username');
+
+        // Launch change of nullability for field password
+        $dbman->change_field_notnull($table, $field);
+
+
+        // Changing nullability of field password on table local_xmlsync_userimport to null.
+        $table = new xmldb_table('local_xmlsync_userimport_tmp');
+        $field = new xmldb_field('password', XMLDB_TYPE_CHAR, '255', null, null, null, null, 'username');
+
+        // Launch change of nullability for field password
+        $dbman->change_field_notnull($table, $field);
+
+        // Xmlsync savepoint reached.
+        upgrade_plugin_savepoint(true, 2022050500, 'local', 'xmlsync');
+    }
+
+    return true;
+}
+
+

--- a/local/xmlsync/lang/en/local_xmlsync.php
+++ b/local/xmlsync/lang/en/local_xmlsync.php
@@ -1,0 +1,78 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Language strings for XML Import.
+ *
+ * @package    local_xmlsync
+ * @author     David Thompson <david.thompson@catalyst.net.nz>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['pluginname'] = 'XML file import tasks';
+
+$string['settings:syncpath'] = 'Sync file directory';
+$string['settings:syncpath_desc'] = 'Absolute path to the directory where XML import files are uploaded to.';
+$string['settings:import_count_threshold'] = 'Import count change threshold';
+$string['settings:import_count_threshold_desc'] = 'If the number of import rows changes by more than this amount, the import will fail. (0 = no checking)';
+$string['settings:stale_threshold'] = 'Stale import threshold';
+$string['settings:stale_threshold_desc'] = 'An import file older that this will be considered "stale". Attempting to import a stale file will send a warning notification. (0 hours = no checking)';
+$string['settings:stale_warning_recipients'] = 'Stale import warning recipients';
+$string['settings:stale_warning_recipients_desc'] = 'A comma-separated list of email addresses to send stale import warnings to. If no addresses are given, site administrators will be notified.';
+$string['settings:email_cooldown'] = 'Email cooldown period';
+$string['settings:email_cooldown_desc'] = 'The minimum elapsed time between sending warning emails. (Warnings will still be noted in the task log.)';
+$string['settings:import_batch_threshold'] = 'The maximum batchsize during the import step';
+$string['settings:import_batch_threshold_desc'] = 'Defines how many records should be read from the xml file and then inserted at once into the database, a higher value is better for performance, but be aware that too large and you might exhaust memory available to the cron task';
+$string['dryruncomplete'] = 'Dry run complete.';
+$string['dryrunmetadata'] = 'Metadata: {$a}';
+$string['importingstart'] = 'Importing records into {$a}...';
+$string['tasklogwarning'] = 'WARNING: {$a}';
+$string['emailcooldownskip'] = 'Warning email has already been sent within cooldown period. Skipping further email.';
+
+
+$string['import:flushentries'] = 'Removing any existing course entries from import temp table {$a}';
+$string['import:filename'] = 'The file in question is - {$a}';
+$string['import:stalefile'] = "The supplied import XML file is older than expected.\nThe import task will continue, but a newer file should be uploaded if available.";
+$string['import:stalefile_timestamp'] = 'ROWSET timestamp given: {$a}';
+$string['import:stalemailsubject'] = 'Warning: Old XML file encountered in import {$a}';
+$string['import:sanitycheck'] = 'Sanity checking delta file';
+$string['import:rowcount'] = '{$a->importcount} rows imported, of which {$a->updatecount} were update actions and {$a->deletecount} were delete actions';
+
+$string['sync:start'] = 'Now aligning the primary table {$a->maintable} with the delta from the import table {$a->importtable}';
+$string['sync:complete'] = 'Alignment complete, new main table record count {$a->post_sync_total}, delta change was {$a->delta}, {$a->deletecount} records were deleted, {$a->updatecount} records were updated, {$a->insertcount} records were created';
+
+$string['courseimport:crontask'] = 'Import Course XML file from SFTP';
+$string['courseimport:starttask'] = 'Importing courses into table';
+$string['courseimport:completetask'] = 'Course import complete.';
+
+$string['enrolimport:crontask'] = 'Import Enrol XML file from SFTP';
+$string['enrolimport:starttask'] = 'Importing enrolment data';
+$string['enrolimport:completetask'] = 'Enrol import complete.';
+
+$string['userimport:crontask'] = 'Import User XML file from SFTP';
+$string['userimport:starttask'] = 'Importing users';
+$string['userimport:completetask'] = 'User import complete.';
+
+$string['error:importcountoverthreshold'] = 'Number of rows in import has exceeded safety threshold (+/- {$a->maxdelta}). Count changed by {$a->delta} rows.';
+$string['error:invalidreplica'] = 'Invalid replica table: {$a}';
+$string['error:noopen'] = 'Could not open file {$a}.';
+$string['error:nosyncpath'] = 'Sync file directory path is not set. Please configure in the settings.';
+$string['error:invalidtable'] = 'Invalid table: {$a}';
+$string['error:unknownaction'] = 'Unknown action in import file: \'{$a}\'';
+
+$string['warning:timestampmatch'] = 'Timestamp exactly matches previously imported file. Importing skipped.';
+$string['warning:dryrun'] = 'Dry run: no table name specified.';

--- a/local/xmlsync/locallib.php
+++ b/local/xmlsync/locallib.php
@@ -1,0 +1,326 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * High-level utility functions for XML import tasks.
+ *
+ * @package    local_xmlsync
+ * @author     David Thompson <david.thompson@catalyst.net.nz>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+// Course uses a non-replicated database, but we may log actions later.
+const COURSEIMPORT_MAIN = 'crsimport';
+const COURSEIMPORT_LOG = 'crsimport_log';
+
+// Enrol and User have replicas for now.
+const ENROLIMPORT_A = 'enrolimport_a';
+const ENROLIMPORT_B = 'enrolimport_b';
+const ENROLIMPORT_REPLICAS = array(ENROLIMPORT_A, ENROLIMPORT_B);
+const ENROLIMPORT_ACTIVE_REPLICA_SETTING = 'enrolimport_activereplica';
+
+const USERIMPORT_A = 'userimport_a';
+const USERIMPORT_B = 'userimport_b';
+const USERIMPORT_REPLICAS = array(USERIMPORT_A, USERIMPORT_B);
+const USERIMPORT_ACTIVE_REPLICA_SETTING = 'userimport_activereplica';
+
+
+/*** Course Import functions ***/
+
+/** Get main table for reading and imports.
+ *
+ * @return string Table name (local_xmlsync_$tablename)
+ */
+function local_xmlsync_get_courseimport_main() {
+    return COURSEIMPORT_MAIN;
+}
+
+/** Get log table for audit and review.
+ *
+ * @return string Table name (local_xmlsync_$logtablename)
+ */
+function local_xmlsync_get_courseimport_log() {
+    return COURSEIMPORT_LOG;
+}
+
+/**
+ * Return deserialized enrol import metadata array.
+ *
+ * @return array|null Metadata from import, if set.
+ */
+function local_xmlsync_get_courseimport_metadata() {
+    $metadata = get_config('local_xmlsync', COURSEIMPORT_MAIN . "_metadata");
+    if ($metadata) {
+        return json_decode($metadata, true);
+    } else {
+        return null;
+    }
+}
+
+/**
+ * Ensure a table name is valid.
+ *
+ * With no replicas, this should be the standable import table name.
+ *
+ * @param string $tablename
+ * @throws \Exception if not valid.
+ * @return void
+ */
+function local_xmlsync_validate_courseimport($tablename) {
+    if ($tablename !== COURSEIMPORT_MAIN) {
+        throw new \Exception(get_string('error:invalidtable', 'local_xmlsync', $tablename));
+    }
+
+}
+
+/*** Enrol Import functions ***/
+
+/**
+ * Get currently active replica name for reading.
+ *
+ * @return string Replica name (local_xmlsync_$replicaname).
+ */
+function local_xmlsync_get_enrolimport_active_replica(): string {
+    $active = get_config('local_xmlsync', ENROLIMPORT_ACTIVE_REPLICA_SETTING);
+    // Default to first replica if none is set.
+    if (empty($active)) {
+        return ENROLIMPORT_A;
+    } else {
+        return $active;
+    }
+}
+
+/**
+ * Get currently inactive replica for XML enrol imports.
+ *
+ * @return string Replica name (local_xmlsync_$replicaname).
+ */
+function local_xmlsync_get_enrolimport_inactive_replica(): string {
+    if (local_xmlsync_get_enrolimport_active_replica() == ENROLIMPORT_A) {
+        return ENROLIMPORT_B;
+    } else {
+        return ENROLIMPORT_A;
+    }
+}
+
+/**
+ * Return deserialized enrol import metadata array.
+ *
+ * @param string $replicaname valid replica name.
+ * @return array|null Metadata from import, if set.
+ */
+function local_xmlsync_get_enrolimport_metadata($replicaname): ?array {
+    local_xmlsync_validate_enrolimport_replica($replicaname);
+    $metadata = get_config('local_xmlsync', "{$replicaname}_metadata");
+    if ($metadata) {
+        return json_decode($metadata, true);
+    } else {
+        return null;
+    }
+}
+
+/**
+ * Ensure a replica name is valid.
+ *
+ * A valid replica name maps to an import table in the database.
+ * E.g.: 'enrolimport_a' <-> local_xmlsync_enrolimport_a
+ *
+ * @param string $replicaname
+ * @throws \Exception if not valid.
+ * @return void
+ */
+function local_xmlsync_validate_enrolimport_replica($replicaname): void {
+    if (!in_array($replicaname, ENROLIMPORT_REPLICAS, true)) {
+        throw new \Exception(get_string('error:invalidreplica', 'local_xmlsync', $replicaname));
+    }
+}
+
+/**
+ * Set active table for XML enrol imports.
+ *
+ * @param string $replicaname Valid replica table name.
+ * @return void
+ */
+function local_xmlsync_set_enrolimport_active_replica($replicaname) {
+    local_xmlsync_validate_enrolimport_replica($replicaname);
+    set_config(ENROLIMPORT_ACTIVE_REPLICA_SETTING, $replicaname, 'local_xmlsync');
+}
+
+
+/*** User Import functions ***/
+
+/**
+ * Get currently active replica name for reading.
+ *
+ * @return string Replica name (local_xmlsync_$replicaname).
+ */
+function local_xmlsync_get_userimport_active_replica(): string {
+    $active = get_config('local_xmlsync', USERIMPORT_ACTIVE_REPLICA_SETTING);
+    // Default to first replica if none is set.
+    if (empty($active)) {
+        return USERIMPORT_A;
+    } else {
+        return $active;
+    }
+}
+
+/**
+ * Get currently inactive replica for XML user imports.
+ *
+ * @return string Replica name (local_xmlsync_$replicaname).
+ */
+function local_xmlsync_get_userimport_inactive_replica(): string {
+    if (local_xmlsync_get_userimport_active_replica() == USERIMPORT_A) {
+        return USERIMPORT_B;
+    } else {
+        return USERIMPORT_A;
+    }
+}
+
+/**
+ * Return deserialized user import metadata array.
+ *
+ * @param string $replicaname valid replica name.
+ * @return array|null Metadata from import, if set.
+ */
+function local_xmlsync_get_userimport_metadata($replicaname): ?array {
+    local_xmlsync_validate_userimport_replica($replicaname);
+    $metadata = get_config('local_xmlsync', "{$replicaname}_metadata");
+    if ($metadata) {
+        return json_decode($metadata, true);
+    } else {
+        return null;
+    }
+}
+
+/**
+ * Ensure a replica name is valid.
+ *
+ * A valid replica name maps to an import table in the database.
+ * E.g.: 'userimport_a' <-> local_xmlsync_userimport_a
+ *
+ * @param string $replicaname
+ * @throws \Exception if not valid.
+ * @return void
+ */
+function local_xmlsync_validate_userimport_replica($replicaname): void {
+    if (!in_array($replicaname, USERIMPORT_REPLICAS, true)) {
+        throw new \Exception(get_string('error:invalidreplica', 'local_xmlsync', $replicaname));
+    }
+}
+
+/**
+ * Set active table for XML user imports.
+ *
+ * @param string $replicaname Valid replica table name.
+ * @return void
+ */
+function local_xmlsync_set_userimport_active_replica($replicaname) {
+    local_xmlsync_validate_userimport_replica($replicaname);
+    set_config(USERIMPORT_ACTIVE_REPLICA_SETTING, $replicaname, 'local_xmlsync');
+}
+
+/*** Generic Functions ***/
+
+/**
+ * Issue warning emails to nominated users.
+ *
+ * A warning will not be issued unless a cooldown period has passed since the last warning.
+ *
+ * @param string $warningmessage A message to send to nominated recipients.
+ * @return void
+ */
+function local_xmlsync_warn_import($warningmessage, $subject): void {
+    $cooldown = get_config('local_xmlsync', 'email_cooldown');
+    $lastwarning = get_config('local_xmlsync', 'lastwarningtimestamp');
+    $now = (new \DateTimeImmutable('now'))->getTimestamp();
+
+    $sendemail = false;
+
+    // Do not re-send warning if within the cooldown period.
+    if ($cooldown && $lastwarning) {
+        $warningdelta = $now - $lastwarning;
+        if ($warningdelta > $cooldown) {
+            $sendemail = true;
+        }
+    }
+
+    // Always note warning in task log.
+    echo get_string('tasklogwarning', 'local_xmlsync', $warningmessage) . "\n";
+
+    if ($sendemail) {
+        $warnlist = local_xmlsync_get_warning_recipients();
+
+        $data = new \core\message\message();
+        $data->component         = 'moodle';
+        $data->name              = 'instantmessage';
+        $data->subject           = $subject;
+        $data->userfrom          = \core_user::get_noreply_user();
+        $data->fullmessage       = $warningmessage;
+        $data->fullmessageformat = FORMAT_PLAIN;
+        $data->contexturl        = new moodle_url('/admin/tasklogs.php', array('filter' => 'local_xmlsync'));
+        $data->contexturlname    = 'Task log';
+
+        foreach ($warnlist as $warnaddress) {
+            // Use dummy user to mail to email addresses that may not have a user.
+            $dummyemailuser = \core_user::get_noreply_user();
+            $dummyemailuser->firstname = false; // Remove "Do not reply to this email" name.
+            $dummyemailuser->email = $warnaddress;
+            $dummyemailuser->emailstop = false;
+            $data->userto = $dummyemailuser;
+
+            message_send($data);
+        }
+        set_config('lastwarningtimestamp', $now, 'local_xmlsync');
+    } else {
+        echo get_string('emailcooldownskip', 'local_xmlsync') . "\n";
+    }
+
+}
+
+/**
+ * Get a list of email addresses to send old file warnings to.
+ *
+ * If the plugin config has no email addresses, fall back to mailing
+ * the site's administrators.
+ *
+ * @return array Array of email addresses
+ */
+function local_xmlsync_get_warning_recipients(): array {
+    global $CFG;
+    $recipients = array();
+
+    $settingrecipients = get_config('local_xmlsync', 'stale_warning_recipients');
+
+    if ($settingrecipients) {
+        // Split and trim comma-separated email values.
+        $parts = explode(',', $settingrecipients);
+        foreach ($parts as $part) {
+            $address = trim($part);
+            $recipients[] = $address;
+        }
+    } else {
+        // Get siteadmin emails.
+        $adminuids = explode(',', $CFG->siteadmins);
+        foreach ($adminuids as $uid) {
+            $user = \core_user::get_user($uid, 'email');
+            $recipients[] = $user->email;
+        }
+    }
+
+    return $recipients;
+}

--- a/local/xmlsync/settings.php
+++ b/local/xmlsync/settings.php
@@ -1,0 +1,65 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Admin settings for XML import task
+ *
+ * @package    local_xmlsync
+ * @author     David Thompson <david.thompson@catalyst.net.nz>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+if ($hassiteconfig) {
+    $settings = new admin_settingpage('local_xmlsync', get_string('pluginname', 'local_xmlsync'));
+    $ADMIN->add('localplugins', $settings);
+
+    $settings->add(new admin_setting_configtext('local_xmlsync/syncpath',
+        get_string('settings:syncpath', 'local_xmlsync'),
+        get_string('settings:syncpath_desc', 'local_xmlsync'), '', PARAM_TEXT
+    ));
+
+    $settings->add(new admin_setting_configtext('local_xmlsync/import_count_threshold',
+        get_string('settings:import_count_threshold', 'local_xmlsync'),
+        get_string('settings:import_count_threshold_desc', 'local_xmlsync'),
+        0, PARAM_INT
+    ));
+
+    $settings->add(new admin_setting_configtext('local_xmlsync/import_batch_threshold',
+    get_string('settings:import_batch_threshold', 'local_xmlsync'),
+    get_string('settings:import_batch_threshold_desc', 'local_xmlsync'),
+    \local_xmlsync\import\base_importer::BATCH_COUNT, PARAM_INT
+    ));
+
+    $settings->add(new admin_setting_configduration('local_xmlsync/stale_threshold',
+        get_string('settings:stale_threshold', 'local_xmlsync'),
+        get_string('settings:stale_threshold_desc', 'local_xmlsync'), (24 * 3600), 3600 // One day default.
+    ));
+
+    $settings->add(new admin_setting_configtext('local_xmlsync/stale_warning_recipients',
+        get_string('settings:stale_warning_recipients', 'local_xmlsync'),
+        get_string('settings:stale_warning_recipients_desc', 'local_xmlsync'),
+        '', PARAM_TEXT
+    ));
+
+    $settings->add(new admin_setting_configduration('local_xmlsync/email_cooldown',
+        get_string('settings:email_cooldown', 'local_xmlsync'),
+        get_string('settings:email_cooldown_desc', 'local_xmlsync'), 3600, 3600 // One hour default.
+    ));
+
+}

--- a/local/xmlsync/version.php
+++ b/local/xmlsync/version.php
@@ -1,0 +1,32 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * XML Import tasks for Unitec New Zealand Ltd
+ *
+ * @package    local_xmlsync
+ * @author     David Thompson <david.thompson@catalyst.net.nz>
+ * @copyright  2021 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die;
+
+$plugin->version   = 2022050500;
+$plugin->release   = '0.1.0';
+$plugin->maturity  = MATURITY_ALPHA;
+$plugin->requires  = 2021051700; // Moodle 3.11 release and upwards.
+$plugin->component = 'local_xmlsync';


### PR DESCRIPTION
We now import the xml files coming into the import process straight into
temporary tables, we then use these temporary tables to compare against
master tables for course, enrol and user, changes are applied to the
master table based on the requested actions in the temporary tables

The master table updates are done as part of a transaction and therefore
only applied once we are satisifed that the changes have completed in a
sucessfull manner.

The enrol_database and auth_database plugins can then be driven off the
three master tables to do user import/creation/updates, course
creation/import/updates and enrolment creation/import/updates

We have extended enrol_database slightly with some extra hooks, to allow
for updating course visibility and then also for creating courses by copying
a given template course (using the moodle async copy api)