### PR TITLE
local_xmlsync Add course category id field support

### DIFF
--- a/local/xmlsync/classes/import/course_importer.php
+++ b/local/xmlsync/classes/import/course_importer.php
@@ -46,6 +46,7 @@ class course_importer extends base_importer {
         'COURSE_SHORTNAME'  => 'course_shortname',
         'COURSE_TEMPLATE'   => 'course_template',
         'COURSE_VISIBILITY' => 'course_visibility',
+        'COURSE_CATEGORY'   => 'course_category',
         'ACTION'            => 'action',
     );
 

--- a/local/xmlsync/db/install.xml
+++ b/local/xmlsync/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="local/xmlsync/db" VERSION="20220519" COMMENT="XMLDB file for Moodle local/xmlsync"
+<XMLDB PATH="local/xmlsync/db" VERSION="20220520" COMMENT="XMLDB file for Moodle local/xmlsync"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -106,6 +106,7 @@
         <FIELD NAME="course_shortname" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="course_template" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false" COMMENT="Assumed same characteristics as course_idnumber"/>
         <FIELD NAME="course_visibility" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="1" SEQUENCE="false" COMMENT="Assuming boolean per {course}.visible."/>
+        <FIELD NAME="course_category" TYPE="char" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="The id of the category the course should be created in"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
@@ -119,6 +120,7 @@
         <FIELD NAME="course_shortname" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
         <FIELD NAME="course_template" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false" COMMENT="Assumed same characteristics as course_idnumber"/>
         <FIELD NAME="course_visibility" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="1" SEQUENCE="false" COMMENT="Assuming boolean per {course}.visible."/>
+        <FIELD NAME="course_category" TYPE="char" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="The id of the category the course should be created in"/>
         <FIELD NAME="action" TYPE="char" LENGTH="2" NOTNULL="true" DEFAULT="?" SEQUENCE="false" COMMENT="Action to take U (Update), D (Delete)"/>
       </FIELDS>
       <KEYS>

--- a/local/xmlsync/db/upgrade.php
+++ b/local/xmlsync/db/upgrade.php
@@ -398,6 +398,28 @@ function xmldb_local_xmlsync_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2022051900, 'local', 'xmlsync');
     }
 
+    if ($oldversion < 2022052000) {
+
+        // Define field course_category to be added to local_xmlsync_crsimport.
+        $table = new xmldb_table('local_xmlsync_crsimport');
+        $field = new xmldb_field('course_category', XMLDB_TYPE_CHAR, '10', null, null, null, null, 'course_visibility');
+
+        // Conditionally launch add field course_category.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field course_category to be added to local_xmlsync_crsimport_tmp.
+        $table = new xmldb_table('local_xmlsync_crsimport_tmp');
+        $field = new xmldb_field('course_category', XMLDB_TYPE_CHAR, '10', null, null, null, null, 'course_visibility');
+
+        // Conditionally launch add field course_category.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }        
+        // Xmlsync savepoint reached.
+        upgrade_plugin_savepoint(true, 2022052000, 'local', 'xmlsync');
+    }
 
     return true;
 }

--- a/local/xmlsync/version.php
+++ b/local/xmlsync/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2022051900;
+$plugin->version   = 2022052000;
 $plugin->release   = '0.1.0';
 $plugin->maturity  = MATURITY_ALPHA;
 $plugin->requires  = 2021051700; // Moodle 3.11 release and upwards.


### PR DESCRIPTION
This allows adding the COURSE_CATEGORY to the xml import so that the
target category can be specified when creating a course