### PR TITLE
local_xmlsync Fix bug with course creation hook

### DIFF
--- a/local/xmlsync/classes/util.php
+++ b/local/xmlsync/classes/util.php
@@ -29,7 +29,7 @@ defined('MOODLE_INTERNAL') || die();
 
 class util {
     /**
-     * Hook for enrol_database to set course visibility.
+     * Hook for enrol_database to set course visibility for first course creation
      *
      * If an xmlsync record with a matching idnumber is found, set course visibility accordingly.
      *
@@ -49,8 +49,7 @@ class util {
         if ($matchingrecord && isset($matchingrecord->course_visibility)) {
             $course->visible = $matchingrecord->course_visibility;
             $course->timemodified = time();
-            $trace->output("Updating course settings for {$course->fullname}, shortname:{$course->shortname}, idnumber:{$course->idnumber}");
-            $DB->update_record('course', $course);
+            $trace->output("Setting course settings for {$course->fullname}, shortname:{$course->shortname}, idnumber:{$course->idnumber}");
         }
     }
 


### PR DESCRIPTION
I accidentally conflated this with the update hook and was trying to
write a database record where one never actually existed in the first
place, causing the task to fail