### PR TITLE
local_xmlsync Correctly set course visibility

### DIFF
--- a/local/xmlsync/classes/util.php
+++ b/local/xmlsync/classes/util.php
@@ -144,7 +144,7 @@ class util {
                     'fullname' => $course->fullname,
                     'shortname' => $course->shortname,
                     'category' => $course->category,
-                    'visible' => $course->visible,
+                    'visible' => $matchingrecord->course_visibility,
                     'startdate' => $course->startdate,
                     'enddate' => $course->enddate,
                     'idnumber' => $course->idnumber,


### PR DESCRIPTION
The backup controller was inheriting the value from the import task,
but the import task doesn't actually support setting it. So we actually
need to get the information from the matching record from the imported
table